### PR TITLE
Fetches username from Github for use in API.

### DIFF
--- a/Api/Endpoints/DocumentEndpoint.cs
+++ b/Api/Endpoints/DocumentEndpoint.cs
@@ -12,6 +12,7 @@ namespace Api.Endpoints
 
             endpoints.MapGet("generate/documentation", (
                    [FromBody] List<string> document,
+                   [FromHeader] string Username,
                    [FromServices] IGenerateDocumentationUsecase _generateDocumentation
                     )
                => _generateDocumentation.GenDocumentation(document)


### PR DESCRIPTION
Reads in the username (`login`) from GitHub when perform the request with the token, and passes it on to the endpoint in the header as `Username`. Improves the error message status, and uses some neat JSON deserializing to read directly into a class created as the return type. Very cool stuff!

As you can see in the change to `DocumentEndpoint.cs`, you can get the Username out from the header quite simply, which you can now pass down to your functions as you see fit. Enjoy :)